### PR TITLE
Destroy chart after saving to file

### DIFF
--- a/src/LayeredChartSvgFileSaver.coffee
+++ b/src/LayeredChartSvgFileSaver.coffee
@@ -55,5 +55,9 @@ module.exports = save: (design, data, schema) ->
   document.body.appendChild(containerDiv) # Otherwise d3 getBBox doesn't work, odd title placement
   chartOptions.bindto = containerDiv
   title = design.titleText
-  chartOptions.onrendered = => _.defer(-> saveSvgToFile(containerDiv, title))
-  c3.generate(chartOptions)
+  chart = null
+  chartOptions.onrendered = => _.defer(->
+    if chart
+      saveSvgToFile(containerDiv, title)
+      chart = chart.destroy())
+  chart = c3.generate(chartOptions)


### PR DESCRIPTION
The downloaded chart's DOM was correctly getting removed, but the chart object itself never got cleaned up.  So it was still hooked up to various browser events that would cause it to regenerate itself, which would then call `onrendered` again, causing the error because the DOM had already been removed.

So it's a good thing you noticed this and that we didn't just try/catch, because it was a resource leak.

(I double-checked to make sure this isn't happening in printing too.  It's not.  Removing the print div is  reliably calling `LayeredChartViewComponent.componentWillUnmount` for all chart views, thus destroying the chart).
