### PR TITLE
Render widgets in order, to preserve intrinsic state

### DIFF
--- a/src/widgets/WidgetContainerComponent.coffee
+++ b/src/widgets/WidgetContainerComponent.coffee
@@ -184,7 +184,11 @@ class Container extends React.Component
     hover = @state.moveHover or @state.resizeHover
 
     # Render blocks in their adjusted position
-    for id, layout of layouts
+    ids = []
+    for id of layouts
+      ids.push id
+    for id in _.sortBy(ids)
+      layout = layouts[id]
       if not hover or id != hover.dragInfo.id
         renderElems.push(@renderLayout(id, layout))
       else


### PR DESCRIPTION
@grassick Turns out this was the only problem.  The render order was getting changed, so React didn't realize re-rendering was unnecessary.
