### PR TITLE
Fix saving layered chart to svg

### DIFF
--- a/src/widgets/charts/LayeredChartSvgFileSaver.coffee
+++ b/src/widgets/charts/LayeredChartSvgFileSaver.coffee
@@ -55,7 +55,8 @@ module.exports = save: (design, data, schema) ->
   title = design.titleText
   chart = null
   onRender = => 
-    _.defer(-> saveSvgToFile(containerDiv, title))
-    chart.destroy()
+    _.defer(->
+      saveSvgToFile(containerDiv, title)
+      chart.destroy())
   chartOptions.onrendered = _.debounce(_.once(onRender), 1000)
   chart = c3.generate(chartOptions)


### PR DESCRIPTION
Chart object was getting destroyed before rendering.

Note I don't think the `debounce` is required either, but I left it in there anyway.
