### PR TITLE
created calendar chart based on d3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "bootstrap": "^3.3.4",
     "lodash": "^2.4.1",
     "c3": "https://github.com/mWater/c3.git#master",
-    "d3": "v3.5.0"
+    "d3": "v3.5.0",
+    "d3-tip": "~0.6.7"
   }
 }

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -83,6 +83,7 @@ gulp.task "libs_js", ->
     "./bower_components/lodash/dist/lodash.js"
     "./bower_components/d3/d3.js"
     "./bower_components/c3/c3.js"
+    "./bower_components/d3-tip/index.js"
   ]).pipe(concat("libs.js"))
     .pipe(gulp.dest("./dist/js/"))
 

--- a/src/demo.coffee
+++ b/src/demo.coffee
@@ -86,13 +86,35 @@ class TestCalendarChart extends React.Component
       { date: "2015-04-23", value: 8 }
       { date: "2015-04-29", value: 1 }
       { date: "2015-06-01", value: 20 }
+      { date: "2017-03-01", value: 1 }
+      { date: "2017-03-02", value: 2 }
+      { date: "2017-03-03", value: 4 }
+      { date: "2017-03-05", value: 5 }
+      { date: "2017-03-06", value: 10 }
+      { date: "2017-03-07", value: 5 }
+      { date: "2017-03-09", value: 1 }
+      { date: "2017-03-15", value: 19 }
+      { date: "2017-03-17", value: 9 }
+      { date: "2017-03-20", value: 1 }
+      { date: "2017-03-21", value: 21 }
+      { date: "2017-03-22", value: 1 }
+      { date: "2017-03-26", value: 8 }
+      { date: "2017-04-09", value: 43 }
+      { date: "2017-04-10", value: 1 }
+      { date: "2017-04-15", value: 6 }
+      { date: "2017-04-16", value: 1 }
+      { date: "2017-04-19", value: 21 }
+      { date: "2017-04-21", value: 4 }
+      { date: "2017-04-23", value: 8 }
+      { date: "2017-04-29", value: 1 }
+      { date: "2017-06-01", value: 20 }
     ]}
     React.createElement(CalendarChartViewComponent, {
       design: {}
       data: calendarData 
 
-      width: 600
-      height: 600
+      width: 500
+      height: 400
       standardWidth: 800 # Ignore this
 
       scope: null # Ignore this

--- a/src/index.css
+++ b/src/index.css
@@ -173,3 +173,16 @@
 .mwater-visualization-markdown p {
   font-size: 12pt;
 }
+
+.d3-tip {
+  line-height: 1;
+  padding: 8px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  border-radius: 2px;
+}
+
+.d3-tip p{
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
Created calendar chart for #134 

cell width is calculated based on available width and same is used as height, so the height of the container is not taken into consideration. If the height is also to be taken into consideration, I will update accordingly.

The colors are quantised and scaled using D3 rgb scaling. You need to set the base color for the cell, which will be used for the minimum value.10 colors are generated and the given data is scaled withinn these 10 colors.

Todo:
- Detect and avoid outliers / years with less than minimum entries? ( This is something to discuss I guess )
