### PR TITLE
fix colormap reset when changing null values

### DIFF
--- a/src/axes/AxisColorEditorComponent.coffee
+++ b/src/axes/AxisColorEditorComponent.coffee
@@ -50,8 +50,6 @@ module.exports = class AxisColorEditorComponent extends AsyncLoadComponent
       newState =
         categories: categories
 
-      console.log _.pluck(props.axis.colorMap, "value")
-      console.log _.pluck(categories, "value")
       if not props.axis.colorMap or !_.isEqual(_.pluck(props.axis.colorMap, "value").sort(), _.pluck(categories, "value").sort())
         colorMap = ColorPaletteCollectionComponent.getColorMapForCategories(categories, axisBuilder.isCategorical(props.axis))
         @onPaletteChange(colorMap)


### PR DESCRIPTION
fix for https://github.com/mWater/mwater-portal/issues/848

The problem was _.isEqual is order sensitive. This fix should also fix the reset on customize as well
