### PR TITLE
dont show tooltip while reloading

### DIFF
--- a/src/widgets/charts/CalendarChartViewComponent.coffee
+++ b/src/widgets/charts/CalendarChartViewComponent.coffee
@@ -98,6 +98,7 @@ module.exports = class CalendarChartViewComponent extends React.Component
 
   # Redraw component
   redraw: ->
+    @reloading = true
     container = @refs.chart_container
     container.innerHTML = ''
     cellSize = @getCellSize()
@@ -146,7 +147,6 @@ module.exports = class CalendarChartViewComponent extends React.Component
       .append("g")
       .attr("transform", "translate("+yearGroupTranslateX+",0)")
 
-
     svg.call(tip)
 
     svg.append("text")
@@ -169,12 +169,16 @@ module.exports = class CalendarChartViewComponent extends React.Component
       .attr("height", cellSize)
       .attr("x", (d) -> d3.time.weekOfYear(d) * cellSize )
       .attr("y", (d) -> d.getDay() * cellSize )
-      .on("mouseenter", tip.show)
+      .on("mouseenter", () => 
+        if not @reloading
+          tip.show()
+      )
       .on("mouseleave", tip.hide)
       .datum(format)
 
     rect.on "click", (e) ->
       tip.hide()
+      # tip.destroy()
       selectedRect = d3.select(this)
       self.handleCellClick selectedRect, e
 
@@ -211,6 +215,7 @@ module.exports = class CalendarChartViewComponent extends React.Component
       .attr("stroke-width", @props.monthsStrokeWidth)
       .attr("d", monthPath)
 
+    @reloading = false  
     return
 
   render: ->
@@ -231,4 +236,3 @@ module.exports = class CalendarChartViewComponent extends React.Component
       if title
         H.p {style: titleStyle, ref: "title"}, title,
       H.div { ref: "chart_container"}
-


### PR DESCRIPTION
#338 

This is a possible fix for the issue.
I am simply setting a flag when the map is reloading and the tip is set to show only if the reload is done. 