### PR TITLE
enhance placeholder in widgets with icons

### DIFF
--- a/src/layout-styles.css
+++ b/src/layout-styles.css
@@ -234,3 +234,24 @@ There are several styles of block layouts:
   font-size: 13px;
   text-align: center;
 }
+
+.mwater-visualization-widget-placeholder {
+  position: absolute;
+  bottom: 0;
+  left: 0px;
+  right: 0px;
+  text-align: center;
+  top: 0;
+  cursor: pointer;
+  background: #f8f8f8;
+}
+
+.mwater-visualization-widget-placeholder .fa,
+.mwater-visualization-widget-placeholder .glyphicon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #f0f0f0;
+  font-size: 60px;
+}

--- a/src/widgets/IFrameWidgetComponent.coffee
+++ b/src/widgets/IFrameWidgetComponent.coffee
@@ -2,6 +2,7 @@ React = require 'react'
 H = React.DOM
 R = React.createElement
 _ = require 'lodash'
+ui = require 'react-library/lib/bootstrap'
 
 DropdownWidgetComponent = require './DropdownWidgetComponent'
 ModalPopupComponent = require('react-library/lib/ModalPopupComponent')
@@ -46,8 +47,10 @@ module.exports = class IFrameWidgetComponent extends React.Component
 
   # Render a link to start editing
   renderEditLink: ->
-    H.div style: { position: "absolute", bottom: @props.height / 2, left: 0, right: 0, textAlign: "center" },
-      H.a className: "btn btn-link", onClick: @handleStartEditing, "Click Here to Configure"
+    H.div className: "mwater-visualization-widget-placeholder", onClick: @handleStartEditing,
+      R ui.Icon, id: "fa-youtube-play"
+    # H.div style: { position: "absolute", bottom: @props.height / 2, left: 0, right: 0, textAlign: "center" },
+    #   H.a className: "btn btn-link", onClick: @handleStartEditing, "Click Here to Configure"
 
   render: ->
     dropdownItems = []

--- a/src/widgets/ImageWidgetComponent.coffee
+++ b/src/widgets/ImageWidgetComponent.coffee
@@ -48,8 +48,8 @@ module.exports = class ImageWidgetComponent extends AsyncLoadComponent
 
   # Render a link to start editing
   renderEditLink: ->
-    H.div style: { position: "absolute", bottom: @props.height / 2, left: 0, right: 0, textAlign: "center" },
-      H.a className: "btn btn-link", onClick: @handleStartEditing, "Click Here to Edit"
+    H.div className: "mwater-visualization-widget-placeholder", onClick: @handleStartEditing, 
+      H.i className: "icon fa fa-image"
 
   renderEditor: ->
     R ImageWidgetDesignComponent,

--- a/src/widgets/charts/Chart.coffee
+++ b/src/widgets/charts/Chart.coffee
@@ -70,3 +70,7 @@ module.exports = class Chart
   # Get a list of table ids that can be filtered on
   getFilterableTables: (design, schema) ->
     throw new Error("Not implemented")
+
+  # Get the chart type
+  getType: ->
+    return 'chart'

--- a/src/widgets/charts/ChartWidget.coffee
+++ b/src/widgets/charts/ChartWidget.coffee
@@ -7,6 +7,13 @@ CsvBuilder = require './../../CsvBuilder'
 ActionCancelModalComponent = require('react-library/lib/ActionCancelModalComponent')
 ChartViewComponent = require './ChartViewComponent'
 ModalWindowComponent = require('react-library/lib/ModalWindowComponent')
+ui = require 'react-library/lib/bootstrap'
+
+placeholderIconMap = 
+  "table": "fa-table"
+  "chart": "fa-bar-chart" 
+  "image-mosaic": "fa-th"
+  "calendar": "fa-calendar"
 
 # A widget which is a chart
 module.exports = class ChartWidget extends Widget
@@ -191,12 +198,8 @@ class ChartWidgetComponent extends React.Component
 
   # Render a link to start editing
   renderEditLink: ->
-    if @props.height
-      H.div style: { position: "absolute", bottom: @props.height / 2, left: 0, right: 0, textAlign: "center" },
-        H.a className: "btn btn-link", onClick: @handleStartEditing, "Click Here to Edit"
-    else
-      H.div style: { position: "absolute", top: "50%", marginTop: -20, left: 0, right: 0, textAlign: "center" },
-        H.a className: "btn btn-link", onClick: @handleStartEditing, "Click Here to Edit"
+    H.div className: "mwater-visualization-widget-placeholder", onClick: @handleStartEditing,
+      R ui.Icon, id: placeholderIconMap[@props.chart.getType()]
 
   render: ->
     design = @props.chart.cleanDesign(@props.design, @props.schema)

--- a/src/widgets/charts/calendar/CalendarChart.coffee
+++ b/src/widgets/charts/calendar/CalendarChart.coffee
@@ -179,3 +179,5 @@ module.exports = class CalendarChart extends Chart
   getFilterableTables: (design, schema) ->
     return _.compact([design.table])
     
+  getType: ->
+    return "calendar"

--- a/src/widgets/charts/imagemosaic/ImageMosaicChart.coffee
+++ b/src/widgets/charts/imagemosaic/ImageMosaicChart.coffee
@@ -177,3 +177,6 @@ module.exports = class ImageMosaicChart extends Chart
   # Get a list of table ids that can be filtered on
   getFilterableTables: (design, schema) ->
     return _.compact([design.table])
+
+  getType: ->
+    return "image-mosaic"

--- a/src/widgets/charts/table/TableChart.coffee
+++ b/src/widgets/charts/table/TableChart.coffee
@@ -265,3 +265,6 @@ module.exports = class TableChart extends Chart
   # Get a list of table ids that can be filtered on
   getFilterableTables: (design, schema) ->
     return _.compact([design.table])
+
+  getType: ->
+    return "table"


### PR DESCRIPTION
#369 
Placeholders added for 
Image
Chart
Table
Calendar
Mosaic

The pivot widget is not using any icon from font-awesome or bootstrap. I looked around and seems making custom icon font from svg is fairly easy. Should we maintain all custom icons that are not available in our own font? 

Here is a sample of the icon font generated for pivot icon
http://broncha.me/demo.html